### PR TITLE
Fix checkdoc warnings: two spaces after periods

### DIFF
--- a/sql-bigquery.el
+++ b/sql-bigquery.el
@@ -28,7 +28,7 @@
 ;;; Commentary:
 
 ;; This package adds comint support for the BigQuery CLI shell to run
-;; queries. It depends on an installed and functional 'google-cloud-sdk'.
+;; queries.  It depends on an installed and functional 'google-cloud-sdk'.
 
 ;;; Code:
 
@@ -240,8 +240,8 @@ bypasses the input-filter chain."
 (defun sql-bigquery-comint (product options &optional buffer-name)
   "Connect to BigQuery in a comint buffer.
 
-PRODUCT is the sql product (bigquery). OPTIONS are any additional
-options to pass to bigquery-shell. BUFFER-NAME is what you'd like
+PRODUCT is the sql product (bigquery).  OPTIONS are any additional
+options to pass to bigquery-shell.  BUFFER-NAME is what you'd like
 the SQLi buffer to be named."
   (let ((params (append '("shell")
                         (unless (string= "" sql-database)


### PR DESCRIPTION
## Summary

`M-x checkdoc` flagged three "There should be two spaces after a period" warnings on `master`:

- `sql-bigquery.el:31` — Commentary header
- `sql-bigquery.el:243-244` — `sql-bigquery-comint` docstring

This adds the second space in each case so `checkdoc` runs cleanly.

Surfaced while verifying the [MELPA submission checklist](https://github.com/melpa/melpa/pull/9938) — the reviewer asked for the PR template to be filled out, and the `checkdoc` checkbox could not be honestly checked until this lands.

## Test plan

- [x] `emacs -Q -batch --eval '(checkdoc-file "sql-bigquery.el")'` exits 0 with no warnings
- [x] `emacs -Q -batch -L . -f batch-byte-compile sql-bigquery.el` still clean
- [x] `package-lint-batch-and-exit` still clean